### PR TITLE
Set css attrs to empty strings instead of null

### DIFF
--- a/sticky.js
+++ b/sticky.js
@@ -15,6 +15,8 @@ angular.module('sticky', [])
 				// Check if our anchor has passed the top of the window
 				//
 				function checkSticky(){
+          if ($elem[0].offsetHeight === 0) return; // return if not visible
+
 					if ($elem.parent()[0].getBoundingClientRect().top - offsetTop <= 0 ) {
 						$elem.css({ top: offsetTop + 'px', position: 'fixed' });
 					} else {

--- a/sticky.js
+++ b/sticky.js
@@ -18,7 +18,7 @@ angular.module('sticky', [])
 					if ($elem.parent()[0].getBoundingClientRect().top - offsetTop <= 0 ) {
 						$elem.css({ top: offsetTop + 'px', position: 'fixed' });
 					} else {
-						$elem.css({ top: null, position: null });
+						$elem.css({ top: '', position: '' });
 					}
 				}
 


### PR DESCRIPTION
Setting to null doesn't work in Chrome anymore.
